### PR TITLE
Assign users with no group memberships 'none'

### DIFF
--- a/src/jupyterhub_cost_monitoring/query_cost_aws.py
+++ b/src/jupyterhub_cost_monitoring/query_cost_aws.py
@@ -586,10 +586,9 @@ def query_total_costs_per_user(
                     r_copy = copy.deepcopy(r)
                     r_copy["usergroup"] = entry["usergroup"]
                     list_groups.append(r_copy)
-            else:
-                logger.debug(f"No username match for group membership: {r['user']}")
-                r["usergroup"] = "none"
-    logger.debug(f"List groups: {list_groups}")
+        if r.get("usergroup") is None:
+            logger.info(f"No username match for group membership: {r}")
+            r["usergroup"] = "none"
     results.extend(list_groups)
     if limit:
         limit = int(limit)


### PR DESCRIPTION
Assign users with no groups to 'none', even if there is no groups-exporter deployed, e.g. a cluster might have no groups-exporter deployed in a namespace with a binderhub running.

Ref https://github.com/2i2c-org/infrastructure/issues/6859