### PR TITLE
Fix user costs grafana dashboard after introducing group costs

### DIFF
--- a/dashboards/cloud-cost-users.jsonnet
+++ b/dashboards/cloud-cost-users.jsonnet
@@ -232,7 +232,7 @@ local Hub =
             "aggregations": [],
             "operation": "groupby"
           },
-          Group: {
+          User: {
             "aggregations": [],
             "operation": "groupby"
           },


### PR DESCRIPTION
This PR fixes the user costs displayed in the User Costs grafana dashboard.

- this was caused by introducing group costs
- users who are members of multiple groups have multiple cost entries
- for the user costs dashboard, we only want to sum the first cost entry, not all cost entries for all groups

Cc @batpad @kyle-lesinger

Ref https://2i2c.freshdesk.com/a/tickets/4367